### PR TITLE
remove excluded topics from sidebar

### DIFF
--- a/content/sidebar.config.js
+++ b/content/sidebar.config.js
@@ -1,16 +1,16 @@
 const config = {
-      forcedNavOrder: [
-        '/introduction',
-        '/1-explore',
-        '/2-focus',
-        '/3-immerse',
-        '/4-plan',
-        '/5-build',
-        '/6-optimize',
-        '/7-harvest',
-        '/8-retire',
-        '/formatting-guidelines'
-      ]
-  };
-  
-  module.exports = config;
+  forcedNavOrder: [
+    "/introduction",
+    "/1-explore",
+    "/2-focus",
+    "/3-immerse",
+    "/4-plan",
+    "/5-build",
+    "/6-optimize",
+    "/7-harvest",
+    "/8-retire",
+  ],
+  excludedTopics: ["formatting-guidelines"],
+};
+
+module.exports = config;

--- a/portal/config.js
+++ b/portal/config.js
@@ -26,11 +26,11 @@ const config = {
   },
   sidebar: {
     forcedNavOrder: sidebarConfig.forcedNavOrder,
+    excludedTopics: sidebarConfig.excludedTopics,
     links: [{ text: 'WinningProduct', link: 'https://winningproduct.com' }],
     frontline: false,
     ignoreIndex: true,
-    title:
-      "",
+    title: '',
   },
   siteMetadata: {
     title: 'Winning Product| Learn',

--- a/portal/src/components/sidebar/tree.js
+++ b/portal/src/components/sidebar/tree.js
@@ -3,6 +3,8 @@ import config from '../../../config';
 import TreeNode from './treeNode';
 
 const calculateTreeData = edges => {
+  const { excludedTopics } = config.sidebar;
+
   const originalData = config.sidebar.ignoreIndex
     ? edges.filter(
         ({
@@ -28,6 +30,11 @@ const calculateTreeData = edges => {
 
       const slicedParts =
         config.gatsby && config.gatsby.trailingSlash ? parts.slice(1, -2) : parts.slice(1, -1);
+
+      const [, mainTopic] = parts;
+      if (excludedTopics.includes(mainTopic)) {
+        return accu;
+      }
 
       for (const part of slicedParts) {
         let tmp = prevItems && prevItems.find(({ label }) => label == part);


### PR DESCRIPTION
Introduced excludedTopic object in the sidebar config , Reason for this is that in the second array.reduce function (tree.js **calculateTreeData()**) to sort the array , have all the topics and subitems in the initial value. Therefore any topic that doens't contain in forcedNavOrder will be positioned in the tail of the array. 
Also this implementation doesn't work to remove a specific sub topic from a main topic. Better approach for that would be to include that information in the frontmatter of the page.  