### PR TITLE
adding checklist to template graphql

### DIFF
--- a/portal/src/templates/docs.js
+++ b/portal/src/templates/docs.js
@@ -70,6 +70,7 @@ export default class MDXRuntimeTest extends Component {
     const metaTitle = mdx.frontmatter.metaTitle;
 
     const metaDescription = mdx.frontmatter.metaDescription;
+    const checklist = mdx.frontmatter.checklist;
 
     const isDraft = !mdx.frontmatter.published;
 
@@ -104,11 +105,12 @@ export default class MDXRuntimeTest extends Component {
           </Edit>
         </div>
         <StyledMainWrapper>
-          {isDraft? (<Draft></Draft>) : null}
-          <blockquote style={{fontSize: "20px"}}><i>{metaDescription}</i></blockquote>
-          <MDXRenderer>
-            {mdx.body}
-          </MDXRenderer>
+          {isDraft ? <Draft></Draft> : null}
+          {checklist ? <div></div> : null}
+          <blockquote style={{ fontSize: '20px' }}>
+            <i>{metaDescription}</i>
+          </blockquote>
+          <MDXRenderer>{mdx.body}</MDXRenderer>
         </StyledMainWrapper>
         <div className={'addPaddTopBottom'}>
           <NextPrevious mdx={mdx} nav={nav} />
@@ -143,6 +145,12 @@ export const pageQuery = graphql`
         metaTitle
         metaDescription
         published
+        checklist {
+          expectation
+          order
+          question
+          version
+        }
       }
     }
     allMdx {


### PR DESCRIPTION
In order to get the checklist in the page-data.json  , checklist obj was added to the docs.json template graphql. 